### PR TITLE
✨Feat[#75] : 데이터 저장로직을 만들었습니다.

### DIFF
--- a/Yetda/Yetda.xcodeproj/project.pbxproj
+++ b/Yetda/Yetda.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		224AAF4F28813A110053E66A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 224AAF4E28813A110053E66A /* Assets.xcassets */; };
 		224AAF5228813A110053E66A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 224AAF5028813A110053E66A /* LaunchScreen.storyboard */; };
 		22801DA628912553009B955E /* Present.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22801DA528912553009B955E /* Present.swift */; };
-		2288476E289272BB00C4B210 /* FirebaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2288476D289272BB00C4B210 /* FirebaseStorageManager.swift */; };
-		22884770289283A700C4B210 /* FirebaseFirestoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2288476F289283A700C4B210 /* FirebaseFirestoreManager.swift */; };
+		2288476E289272BB00C4B210 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2288476D289272BB00C4B210 /* StorageManager.swift */; };
+		22884770289283A700C4B210 /* FirestoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2288476F289283A700C4B210 /* FirestoreManager.swift */; };
 		22950155288FB87F0050BE44 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 22950154288FB87F0050BE44 /* GoogleService-Info.plist */; };
 		22E1AD49288FDAAD0031E911 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 22E1AD48288FDAAD0031E911 /* GoogleService-Info.plist */; };
 		22EEF862288FE13F0046ECB8 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22EEF861288FE13F0046ECB8 /* Home.storyboard */; };
@@ -96,8 +96,8 @@
 		224AAF5128813A110053E66A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		224AAF5328813A110053E66A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22801DA528912553009B955E /* Present.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Present.swift; sourceTree = "<group>"; };
-		2288476D289272BB00C4B210 /* FirebaseStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageManager.swift; sourceTree = "<group>"; };
-		2288476F289283A700C4B210 /* FirebaseFirestoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFirestoreManager.swift; sourceTree = "<group>"; };
+		2288476D289272BB00C4B210 /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
+		2288476F289283A700C4B210 /* FirestoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreManager.swift; sourceTree = "<group>"; };
 		22950154288FB87F0050BE44 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		22A72FBD2890C71500FC3B96 /* Yetda.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Yetda.entitlements; sourceTree = "<group>"; };
 		22E1AD48288FDAAD0031E911 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -215,8 +215,8 @@
 				6EC305822893ABCD00F9A34F /* UserSiteModel.swift */,
 				224AAF4428813A0F0053E66A /* SceneDelegate.swift */,
 				224AAF4628813A0F0053E66A /* ViewController.swift */,
-				2288476D289272BB00C4B210 /* FirebaseStorageManager.swift */,
-				2288476F289283A700C4B210 /* FirebaseFirestoreManager.swift */,
+				2288476D289272BB00C4B210 /* StorageManager.swift */,
+				2288476F289283A700C4B210 /* FirestoreManager.swift */,
 				224AAF4828813A0F0053E66A /* Main.storyboard */,
 				13E7EE65288ABD9F001090EC /* LocalizingFile.strings */,
 				224AAF4E28813A110053E66A /* Assets.xcassets */,
@@ -477,7 +477,7 @@
 				6E27CDAC288E61E9009B9691 /* ShareButton+Extension.swift in Sources */,
 				2241F11C288AB1900044E704 /* OnBoardingViewController.swift in Sources */,
 				736D28742885331D00F95DFD /* CardCell.swift in Sources */,
-				22884770289283A700C4B210 /* FirebaseFirestoreManager.swift in Sources */,
+				22884770289283A700C4B210 /* FirestoreManager.swift in Sources */,
 				2FE866F5288E7103002242B0 /* DummyData.swift in Sources */,
 				22801DA628912553009B955E /* Present.swift in Sources */,
 				2241F12F288AB37F0044E704 /* SiteModel.swift in Sources */,
@@ -493,7 +493,7 @@
 				2241F130288AB37F0044E704 /* SiteViewController.swift in Sources */,
 				224AAF4328813A0F0053E66A /* AppDelegate.swift in Sources */,
 				5DDD60F028853EC40077742D /* MakeCardDescriptionViewController.swift in Sources */,
-				2288476E289272BB00C4B210 /* FirebaseStorageManager.swift in Sources */,
+				2288476E289272BB00C4B210 /* StorageManager.swift in Sources */,
 				6E27CDAE288E621F009B9691 /* AbleShareKaKao.swift in Sources */,
 				6EC305792893AAB200F9A34F /* SearchResultViewController.swift in Sources */,
 				2FE866EE288E7061002242B0 /* MapCell.swift in Sources */,
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = Yetda/Yetda.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PCJ686F4KQ;
+				DEVELOPMENT_TEAM = JASCMY8XL7;
 				"EXCLUDED_ARCHS[sdk=*]" = arm64;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -683,7 +683,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Yetda;
+				PRODUCT_BUNDLE_IDENTIFIER = sdd.com.Yetda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -701,7 +701,7 @@
 				CODE_SIGN_ENTITLEMENTS = Yetda/Yetda.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PCJ686F4KQ;
+				DEVELOPMENT_TEAM = JASCMY8XL7;
 				"EXCLUDED_ARCHS[sdk=*]" = arm64;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -720,7 +720,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Yetda;
+				PRODUCT_BUNDLE_IDENTIFIER = sdd.com.Yetda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Yetda/Yetda.xcodeproj/xcuserdata/parkgeunil.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Yetda/Yetda.xcodeproj/xcuserdata/parkgeunil.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Yetda.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>39</integer>
+			<integer>36</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Yetda/Yetda/FirestoreManager.swift
+++ b/Yetda/Yetda/FirestoreManager.swift
@@ -8,11 +8,11 @@
 import Foundation
 import FirebaseFirestore
 
-class FirebaseFirestoreManager {
+class FirestoreManager {
     
-    var db = Firestore.firestore()
     // id 값이 있는 경우에는 수정, 없는 경우에는 UUID를 새롭게 만들어서 넣어줌.
-    func uploadData(present: Present) {
+    static func uploadData(present: Present) {
+        let db = Firestore.firestore()
         var documentId: String = ""
         if let id = present.id { documentId = id } else { documentId = UUID().uuidString }
         let stringData: [String: Any] = ["id": documentId,
@@ -35,7 +35,9 @@ class FirebaseFirestoreManager {
         }
     }
     
-    func deleteData(present: Present) {
+    static func deleteData(present: Present) {
+        let db = Firestore.firestore()
+    
         if let id = present.id {
             db.collection("presents").document(id).delete() { err in
                 if let err = err {

--- a/Yetda/Yetda/Home/HomeViewController.swift
+++ b/Yetda/Yetda/Home/HomeViewController.swift
@@ -74,7 +74,7 @@ class HomeViewController: UIViewController {
         self.topView.addGestureRecognizer(touchGesture)
         
         // Firestore DB 읽기
-        db.collection("presents").addSnapshotListener { snapshot, error in
+        db.collection("presents").whereField("user", isEqualTo: "testUser").addSnapshotListener { snapshot, error in
             guard let documents = snapshot?.documents else {
                 print("ERROR Firestore fetching document \(String(describing: error?.localizedDescription))")
                 return

--- a/Yetda/Yetda/Home/HomeViewController.swift
+++ b/Yetda/Yetda/Home/HomeViewController.swift
@@ -74,24 +74,24 @@ class HomeViewController: UIViewController {
         self.topView.addGestureRecognizer(touchGesture)
         
         // Firestore DB 읽기
-//        db.collection("presents").addSnapshotListener { snapshot, error in
-//            guard let documents = snapshot?.documents else {
-//                print("ERROR Firestore fetching document \(String(describing: error?.localizedDescription))")
-//                return
-//            }
-//
-//            self.presents = documents.compactMap { doc -> Present? in
-//                do {
-//                    let jsonData = try JSONSerialization.data(withJSONObject: doc.data(), options: [])
-//                    let present = try JSONDecoder().decode(Present.self, from: jsonData)
-//                    return present
-//                } catch let error {
-//                    print("ERROR JSON Parsing \(error)")
-//                    return nil
-//                }
-//            }
-//            print(self.presents)
-//        }
+        db.collection("presents").addSnapshotListener { snapshot, error in
+            guard let documents = snapshot?.documents else {
+                print("ERROR Firestore fetching document \(String(describing: error?.localizedDescription))")
+                return
+            }
+
+            self.presents = documents.compactMap { doc -> Present? in
+                do {
+                    let jsonData = try JSONSerialization.data(withJSONObject: doc.data(), options: [])
+                    let present = try JSONDecoder().decode(Present.self, from: jsonData)
+                    return present
+                } catch let error {
+                    print("ERROR JSON Parsing \(error)")
+                    return nil
+                }
+            }
+            print(self.presents)
+        }
     }
     
     @objc func longTap(_ gesture: UIGestureRecognizer) {
@@ -265,7 +265,7 @@ class HomeViewController: UIViewController {
                     imagePicker.dismiss(animated: false)
                     let storyboard = UIStoryboard(name: "MakeCard", bundle: nil)
                     let makeCardVC = storyboard.instantiateViewController(withIdentifier: "MakeCard")
-                    self.present(makeCardVC, animated: true)
+                    self.navigationController?.pushViewController(makeCardVC, animated: true)
                 }
                 imagePicker.view.backgroundColor = .white
                 self.present(imagePicker, animated: true)

--- a/Yetda/Yetda/MakeCard/MakeCardDescriptionViewController.swift
+++ b/Yetda/Yetda/MakeCard/MakeCardDescriptionViewController.swift
@@ -136,16 +136,6 @@ class MakeCardDescriptionViewController: UIViewController, UICollectionViewDeleg
         
     }
     
-    @IBAction func saveButton(_ sender: UIButton) {
-        let selectedImage = UIImage(named: "photo1")
-//        guard let user = Auth.auth().currentUser else { return }
-                
-        let imageURL = StorageManager.uploadImage(image: selectedImage!)
-        
-        print(imageURL)
-    }
-    
-    
     func textFieldDidBeginEditing(_ textField: UITextField) {
         textField.layer.borderColor = UIColor(named: "YettdaMainLightBlue")?.cgColor
         textField.backgroundColor = UIColor(red: 211/255, green: 225/255, blue: 253/255, alpha: 0.1)

--- a/Yetda/Yetda/MakeCard/MakeCardDescriptionViewController.swift
+++ b/Yetda/Yetda/MakeCard/MakeCardDescriptionViewController.swift
@@ -140,7 +140,7 @@ class MakeCardDescriptionViewController: UIViewController, UICollectionViewDeleg
         let selectedImage = UIImage(named: "photo1")
 //        guard let user = Auth.auth().currentUser else { return }
                 
-        let imageURL = FirebaseStorageManager.uploadImage(image: selectedImage!)
+        let imageURL = StorageManager.uploadImage(image: selectedImage!)
         
         print(imageURL)
     }

--- a/Yetda/Yetda/MakeCard/MakeCardStoryViewController.swift
+++ b/Yetda/Yetda/MakeCard/MakeCardStoryViewController.swift
@@ -14,7 +14,26 @@ class MakeCardStoryViewController: UIViewController, UICollectionViewDelegate, U
     @IBOutlet weak var numbersTyped: UILabel!
     @IBOutlet weak var storyTypeLimit: UILabel!
     @IBOutlet weak var nextButton: UIButton!
+    
     @IBAction func nextButton(_ sender: Any) {
+        
+        // 데이터 저장로직 누르자마자 저장 로직과는 별개로 바로 이동할 수 있도록 비동기로 처리함
+        // 애초에 데이터 저장하고 넘어가는 UI를 실행하는 것은 텀이 생기게 돼서 iOS에서 터트림.
+        DispatchQueue.global().sync {
+            let images: [UIImage] = [UIImage(named: "photo1")!, UIImage(named: "photo2")!]
+            let imageURLs: [String] = StorageManager.uploadImages(images: images)
+            FirestoreManager.uploadData(present: Present(id: nil,
+                                                         user: "testUser",
+                                                         site: "testSite",
+                                                         name: "testName",
+                                                         content: "testContent",
+                                                         whosFor: "testFor",
+                                                         date: "testDate",
+                                                         keyWords: ["testKeyword1", "testKeyword2", "testKeyword3", "testKeyword4"],
+                                                         images: imageURLs,
+                                                         coordinate: ["coordinate1", "coordinate2"]))
+        }
+        
         let storyboard = UIStoryboard(name: "Home", bundle: nil)
         let vc = storyboard.instantiateViewController(withIdentifier: "HomeViewController") as! HomeViewController
         

--- a/Yetda/Yetda/Model/Present.swift
+++ b/Yetda/Yetda/Model/Present.swift
@@ -19,4 +19,17 @@ struct Present: Hashable, Codable {
     var keyWords: [String]
     var images: [String]
     var coordinate: [String]
+    
+    init(id: String?, user: String, site: String, name: String, content: String, whosFor: String, date: String, keyWords: [String], images: [String], coordinate: [String]) {
+        self.id = id
+        self.user = user
+        self.site = site
+        self.name = name
+        self.content = content
+        self.whosFor = whosFor
+        self.date = date
+        self.keyWords = keyWords
+        self.images = images
+        self.coordinate = coordinate
+    }
 }

--- a/Yetda/Yetda/OnBoarding/OnBoardingViewController.swift
+++ b/Yetda/Yetda/OnBoarding/OnBoardingViewController.swift
@@ -13,7 +13,7 @@ class OnBoardingViewController: UIPageViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        self.navigationController?.setNavigationBarHidden(true, animated: true)
         self.makePageVC()
     }
     

--- a/Yetda/Yetda/Search/SearchResultViewController.swift
+++ b/Yetda/Yetda/Search/SearchResultViewController.swift
@@ -144,7 +144,7 @@ extension SearchResultViewController: UICollectionViewDelegate {
     }
 }
 
-extension UIViewController {
+extension SearchResultViewController {
     // UserDefault 값 넣는 함수
     // 인자로 지역의 이름을 영문으로 넣어 주시면 됩니다.
     func setSiteUserDefault(site: String) {

--- a/Yetda/Yetda/StorageManager.swift
+++ b/Yetda/Yetda/StorageManager.swift
@@ -9,10 +9,21 @@ import UIKit
 import Firebase
 import FirebaseStorage
 
-class FirebaseStorageManager {
-
-    static func uploadImage(image: UIImage) -> String {
+class StorageManager {
+    
+    static func uploadImages(images: [UIImage]) -> [String] {
+        var result = [String]()
         
+        for image in images {
+            result.append(uploadImage(image: image))
+        }
+        
+        return result
+    }
+
+    static func uploadImage(image: UIImage?) -> String {
+        
+        guard let image = image else { return "" }
         guard let imageData = image.jpegData(compressionQuality: 0.4) else { return "" }
         let imageName = UUID().uuidString + String(Date().timeIntervalSince1970)
         


### PR DESCRIPTION
### Motivation

카드를 만들 때 이미지를 Firebase에 저장하는 로직을 만들어야했습니다.
미리 StorageManager, FirestoreManager를 만들어놨어서 작업하기 편했습니다.

### Key Change
데이터 쪽 로직 후에 바로 UI 로직이 있을 경우 텀이 생기면 iOS가 앱을 터트리도록 설계되어 있어 데이터 저장 로직은 비동기로 처리했습니다. 나중에 모든 데이터들이 MakeCardStoryViewController에 있을 경우 객체 init 쪽에 넣어주기만 하면 됩니다.

![image](https://user-images.githubusercontent.com/77421835/182010266-c9787763-97e4-4bd9-8654-e53d29efc672.png)

HomeView로 이동한 후에는 아래 이미지 코드의 현재 유저의 email에 맞는 데이터만 스냅샷이 보고 있다가 데이터의 변동을 파악해서 뷰를 다시 그려줄 겁니다.

![image](https://user-images.githubusercontent.com/77421835/182015682-85257c28-1e81-4fed-bf01-a634d357595a.png)

### To Reviewers

현재 View와 데이터가 이어져 있지 않아 View가 다시 그려지는 것까지는 확인하지 못했지만 위의 코드에 print문이 두번 실행되는 것으로 보아 1차로 위에서 데이터 저장이 끝나기 전에 뷰가 새롭게 로드됐을 때, 2차로 데이터 저장이 끝난 후에 또 실행되는 것까지 파악했습니다.
