### PR TITLE
🎨  : 검색 결과 백그라운드뷰 수정, 온보딩 present 형태로 변경

### DIFF
--- a/Yetda/Yetda/Home/HomeViewController.swift
+++ b/Yetda/Yetda/Home/HomeViewController.swift
@@ -56,10 +56,13 @@ class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // MARK: 모달로 연결 후에 init 대신에 아래 코드로 하겠습니다.
-        // self.city = defaults.string(forKey: "site")
+        // self.city = defaults.string(forKey: "site") ?? "여행지를 추가 해주세요 !"
         let showOnBoarding = defaults.bool(forKey: "isFirst")
         if !showOnBoarding {
-            self.navigationController?.pushViewController(OnBoardingViewController(), animated: false)
+            let vc = OnBoardingViewController()
+            vc.modalPresentationStyle = .overFullScreen
+            self.present(vc, animated: true)
+            //self.navigationController?.pushViewController(OnBoardingViewController(), animated: false)
         }
     }
     

--- a/Yetda/Yetda/Search/SearchResultViewController.swift
+++ b/Yetda/Yetda/Search/SearchResultViewController.swift
@@ -63,6 +63,19 @@ class SearchResultViewController: UIViewController {
         return collectionView
     }()
   
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        switch dismissView {
+        case .Nothing :
+            self.emptyView.backgroundColor = UIColor(named: "YettdaMainBackground")
+            self.collectionView.backgroundColor = UIColor(named: "YettdaMainBackground")
+        case .OnBoarding :
+            return
+        case .none :
+            return
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()

--- a/Yetda/Yetda/Site/SiteViewController.swift
+++ b/Yetda/Yetda/Site/SiteViewController.swift
@@ -158,7 +158,7 @@ class SiteViewController: UIViewController {
     
     private func setupResultViewUI() {
         searchResultViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        searchResultViewController.view.topAnchor.constraint(equalTo: siteSearchBar.bottomAnchor,constant: 10).isActive = true
+        searchResultViewController.view.topAnchor.constraint(equalTo: siteSearchBar.bottomAnchor,constant: -4).isActive = true
         searchResultViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         searchResultViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         searchResultViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
@@ -169,9 +169,7 @@ extension SiteViewController: UISearchBarDelegate {
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         beginAppearanceTransition(true, animated: true)
         view.addSubview(searchResultViewController.view)
-        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            self.searchResultViewController.view.layer.opacity = 1
             self.searchResultViewController.view.layer.cornerRadius = 2
             self.searchResultViewController.view.isHidden = false
         }
@@ -199,6 +197,7 @@ extension SiteViewController: UISearchBarDelegate {
         searchBar.resignFirstResponder()
     }
 }
+
 extension SiteViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         defaults.set(siteDataSource.itemIdentifier(for: indexPath), forKey: "site")


### PR DESCRIPTION
### Motivation

검색 결과의 컬렉션 뷰의 백그라운드 컬러를 맞출 필요가 있었습니다.
처음 앱을 켰을때 보여주는 온보딩 뷰를 네비게이션 보다는 present로 통일 하는게 좋지 않을까 했습니다.

### Key Change

검색결과뷰 컬러변경, OnboardingView present로 보여주도록 변경

### To Reviewer

온보딩 뷰의 Present에 대해서 조금 얘기를 해보면 좋을듯 push보다 오늘 present로 다시 해보니 저는 갠적으로 괜찮은데,, 얘기해보져~

